### PR TITLE
Redirect to Main network after launch

### DIFF
--- a/src/common/Layout/Header/HeaderUpMD.tsx
+++ b/src/common/Layout/Header/HeaderUpMD.tsx
@@ -159,13 +159,15 @@ function Index(props: any) {
 
   const handleNetworkMenuClose = (network?: string) => {
     if (network) {
+      /*
       if (network === 'main') {
         localStorage.setItem('network', 'main');
         window.location.href = '/main';
       } else if (network !== userNetwork) {
-        localStorage.setItem('network', network);
-        window.location.href = '/';
-      }
+      */
+      localStorage.setItem('network', network);
+      window.location.href = '/';
+      // }
     }
     setNetworkMenu(null);
   };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ import store, { history } from './rootStore';
 const Search = lazy(() => import('./modules/Search/adapter'));
 const Home = lazy(() => import('./modules/Home/adapter'));
 const NetworkRedirect = lazy(() => import('./modules/NetworkRedirect/index'));
-const MainnetCountdown = lazy(() => import('./modules/MainnetCountdown/index'));
+// const MainnetCountdown = lazy(() => import('./modules/MainnetCountdown/index'));
 const Blocks = lazy(() => import('./modules/Blocks/containers'));
 const Transactions = lazy(() => import('./modules/Transactions/containers'));
 const Ecosystems = lazy(() => import('./modules/Ecosystems'));
@@ -65,7 +65,7 @@ ReactDOM.render(
         <RouteWithLayout exact path={withBaseRoute('/barnard')} title="NetworkRedirect" layout={MainLayout} component={NetworkRedirect} />
         <RouteWithLayout exact path={withBaseRoute('/halley')} title="NetworkRedirect" layout={MainLayout} component={NetworkRedirect} />
         <RouteWithLayout exact path={withBaseRoute('/proxima')} title="NetworkRedirect" layout={MainLayout} component={NetworkRedirect} />
-        <RouteWithLayout exact path={withBaseRoute('/main')} title="NetworkRedirect" layout={MainLayout} component={MainnetCountdown} />
+        <RouteWithLayout exact path={withBaseRoute('/main')} title="NetworkRedirect" layout={MainLayout} component={NetworkRedirect} />
         <RouteWithLayout exact path={withBaseRoute('/ecosystems')} title="Ecosystem" layout={MainLayout} component={Ecosystems} />
         <RouteWithLayout exact path={withBaseRoute('/faq')} title="Faq" layout={MainLayout} component={Faq} />
         <RouteWithLayout path={withBaseRoute('/:network/address/:hash')} title="Address" layout={MainLayout} component={Address} />

--- a/src/modules/Home/index.tsx
+++ b/src/modules/Home/index.tsx
@@ -179,10 +179,12 @@ class Index extends PureComponent<IndexProps, IndexState> {
   }
 
   componentDidMount() {
-    const currentNetwork = getNetwork();
+    // const currentNetwork = getNetwork();
+    /*
     if (currentNetwork === 'main') {
       window.location.href = '/main';
     }
+    */
 
     // check redirection
     const { location } = this.props;

--- a/src/modules/MainnetCountdown/index.tsx
+++ b/src/modules/MainnetCountdown/index.tsx
@@ -278,7 +278,8 @@ class Index extends PureComponent<IndexProps, IndexState> {
   );
 
   render() {
-    const Home = lazy(() => import('../Home/adapter'));
+    // const Home = lazy(() => import('../Home/adapter'));
+    const NetworkRedirect = lazy(() => import('../NetworkRedirect/index'));
 
     const { t, i18n } = this.props;
 
@@ -296,7 +297,8 @@ class Index extends PureComponent<IndexProps, IndexState> {
     // let date;
 
     if (this.state.barnardLatestInfo !== []) {
-      currentBlock = this.state.barnardLatestInfo[0];
+      // currentBlock = this.state.barnardLatestInfo[0];
+      currentBlock = 310000;
       if (currentBlock >= mainnetBlock) {
         mainnetOnline = true;
       }
@@ -517,7 +519,7 @@ class Index extends PureComponent<IndexProps, IndexState> {
                   <LinearProgress
                     variant="determinate"
                     color="primary"
-                    value={(currentBlock / mainnetBlock) * 100}
+                    value={currentBlock ? ((currentBlock / mainnetBlock) * 100) : 100}
                     style={{
                       height: 10,
                       marginRight: '-1px',
@@ -956,7 +958,11 @@ class Index extends PureComponent<IndexProps, IndexState> {
           </Grid>
         </>
       )
-        : <Home />
+        : <NetworkRedirect
+            location={{
+              pathname: '/main'
+            }}
+        />
     );
   }
 }


### PR DESCRIPTION
If the blockchain explorer does not work as expected when launching at 12pm, 18th May, this PR will be merged to make it redirect to the Main network forcibly.