### PR TITLE
Get single uncle block info by its hash instead of height

### DIFF
--- a/src/modules/UncleBlocks/components/Detail/index.tsx
+++ b/src/modules/UncleBlocks/components/Detail/index.tsx
@@ -49,7 +49,7 @@ class Index extends PureComponent<IndexProps, IndexState> {
     this.state = {
       epochData: undefined,
       hash: props.match.params.hash,
-      height: props.match.params.height
+      height: props.match.params.height,
     };
   }
 

--- a/src/modules/UncleBlocks/components/Table/index.tsx
+++ b/src/modules/UncleBlocks/components/Table/index.tsx
@@ -40,7 +40,7 @@ class Index extends React.PureComponent<Props> {
     const authorValues: any[] = [];
     blocks.forEach((block: any) => {
       const header = block.header;
-      const blockUrl = `/${getNetwork()}/uncleblocks/height/${header.number}`;
+      const blockUrl = `/${getNetwork()}/uncleblocks/hash/${header.block_hash}`;
       const authorUrl = `/${getNetwork()}/address/${header.author}`;
       heightValues.push(<BaseRouteLink to={blockUrl}>{formatNumber(header.number)}</BaseRouteLink>);
       timeValues.push(<CommonTime time={header.timestamp} />);

--- a/src/modules/UncleBlocks/containers/index.tsx
+++ b/src/modules/UncleBlocks/containers/index.tsx
@@ -12,8 +12,8 @@ class BlocksRouter extends PureComponent<BlocksRouterProps> {
     const { computedMatch: match } = this.props;
     return (
       <Switch>
-        <Route path={`${match.path}/height/:height`} render={(props: any) => (<Detail {...props} />)} />
-        <Route path={`${match.path}/detail/:hash`} render={(props: any) => (<Detail {...props} />)} />
+        <Route path={`${match.path}/height/:height/:author`} render={(props: any) => (<Detail {...props} />)} />
+        <Route path={`${match.path}/hash/:hash`} render={(props: any) => (<Detail {...props} />)} />
         <Route path={`${match.path}/:page`} render={(props: any) => (<List {...props} />)} />
       </Switch>
     );


### PR DESCRIPTION
There may be 1 or 2 uncle blocks at one specific height, so use hash instead of height to get the info a specific uncle block.